### PR TITLE
Fix style consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ EasyButton button(BUTTON_PIN);
 
 The class constructor takes the following additional arguments:
 
-**dbTime** : Debounce time in milliseconds.
+**debounce_time** : Debounce time in milliseconds.
 
-**puEnable** : Use or not the internal pullup resistor. Enabled by default.
+**pullup_enable** : Use or not the internal pullup resistor. Enabled by default.
 
 > If using ESP32, be aware that some of the pins does not have software pullup/down functions. Use an external pullup resistor, 10K works well. Refer to [Pull-up Resistors](https://learn.sparkfun.com/tutorials/pull-up-resistors).
 
@@ -52,7 +52,7 @@ The class constructor takes the following additional arguments:
 
 ```c++
 // EasyButton class's constructor signature
-EasyButton(uint8_t pin, uint32_t dbTime = 35, uint8_t puEnable = true, uint8_t invert = true)
+EasyButton(uint8_t pin, uint32_t debounce_time = 35, uint8_t pullup_enable = true, uint8_t invert = true)
 ```
 
 #### Initialize Button Object

--- a/examples/Pressed/Pressed.ino
+++ b/examples/Pressed/Pressed.ino
@@ -15,19 +15,19 @@ EasyButton button(BUTTON_PIN);
 
 // Callback function to be called when the button is pressed.
 void onPressed() {
-	Serial.println("Button has been pressed!");
+  Serial.println("Button has been pressed!");
 }
 
 void setup() {
-	// Initialize Serial for debuging purposes.
-	Serial.begin(115200);
-	// Initialize the button.
-	button.begin();
-	// Add the callback function to be called when the button is pressed.
-	button.onPressed(onPressed);
+  // Initialize Serial for debuging purposes.
+  Serial.begin(115200);
+  // Initialize the button.
+  button.begin();
+  // Add the callback function to be called when the button is pressed.
+  button.onPressed(onPressed);
 }
 
 void loop() {
-	// Continuously read the status of the button. 
-	button.read();
+  // Continuously read the status of the button. 
+  button.read();
 }

--- a/examples/PressedForDuration/PressedForDuration.ino
+++ b/examples/PressedForDuration/PressedForDuration.ino
@@ -15,19 +15,19 @@ EasyButton button(BUTTON_PIN);
 
 // Callback function to be called when the button is pressed.
 void onPressedForDuration() {
-	Serial.println("Button has been pressed!");
+  Serial.println("Button has been pressed!");
 }
 
 void setup() {
-	// Initialize Serial for debuging purposes.
-	Serial.begin(115200);
-	// Initialize the button.
-	button.begin();
-	// Add the callback function to be called when the button is pressed for at least the given time.
-	button.onPressedFor(2000, onPressedForDuration);
+  // Initialize Serial for debuging purposes.
+  Serial.begin(115200);
+  // Initialize the button.
+  button.begin();
+  // Add the callback function to be called when the button is pressed for at least the given time.
+  button.onPressedFor(2000, onPressedForDuration);
 }
 
 void loop() {
-	// Continuously read the status of the button. 
-	button.read();
+  // Continuously read the status of the button. 
+  button.read();
 }

--- a/examples/Sequence/Sequence.ino
+++ b/examples/Sequence/Sequence.ino
@@ -15,19 +15,19 @@ EasyButton button(BUTTON_PIN);
 
 // Callback function to be called when the button is pressed.
 void onSequenceMatched() {
-	Serial.println("Button has been pressed!");
+  Serial.println("Button has been pressed!");
 }
 
 void setup() {
-	// Initialize Serial for debuging purposes.
-	Serial.begin(115200);
-	// Initialize the button.
-	button.begin();
-	// Add the callback function to be called when the given sequence of presses is matched.
-	button.onSequence(5 /* number of presses */, 2000 /* timeout */, onSequenceMatched /* callback */);
+  // Initialize Serial for debuging purposes.
+  Serial.begin(115200);
+  // Initialize the button.
+  button.begin();
+  // Add the callback function to be called when the given sequence of presses is matched.
+  button.onSequence(5 /* number of presses */, 2000 /* timeout */, onSequenceMatched /* callback */);
 }
 
 void loop() {
-	// Continuously read the status of the button. 
-	button.read();
+  // Continuously read the status of the button. 
+  button.read();
 }

--- a/src/EasyButton.cpp
+++ b/src/EasyButton.cpp
@@ -20,20 +20,20 @@ void EasyButton::begin()
 
 void EasyButton::onPressed(EasyButton::callback_t callback)
 {
-	_pressedCallback = callback;
+	_pressed_callback = callback;
 }
 
 void EasyButton::onPressedFor(uint32_t duration, EasyButton::callback_t callback)
 {
 	_held_threshold = duration;
-	_pressedForCallback = callback;
+	_pressed_for_callback = callback;
 }
 
 void EasyButton::onSequence(uint8_t sequences, uint32_t duration, EasyButton::callback_t callback)
 {
 	_press_sequences = sequences;
 	_press_sequence_duration = duration;
-	_pressedSequenceCallback = callback;
+	_pressed_sequence_callback = callback;
 }
 
 bool EasyButton::isPressed()
@@ -108,13 +108,13 @@ bool EasyButton::read()
 			_short_press_count++;
 			// button is not being held.
 			// call the callback function for a short press event if it exist.
-			if (_pressedCallback) {
-				_pressedCallback();
+			if (_pressed_callback) {
+				_pressed_callback();
 			}
 
 			if (_short_press_count == _press_sequences && _press_sequence_duration >= (read_started_ms - _first_press_time)) {
-				if (_pressedSequenceCallback) {
-					_pressedSequenceCallback();
+				if (_pressed_sequence_callback) {
+					_pressed_sequence_callback();
 				}
 				_short_press_count = 0;
 				_first_press_time = 0;
@@ -129,20 +129,20 @@ bool EasyButton::read()
 		else {
 			_was_btn_held = false;
 		}
-		// since button released, reset _pressedForCallbackCalled value.
+		// since button released, reset _pressed_for_callbackCalled value.
 		_held_callback_called = false;
 	}
 	// button is not released.
-	else if (_current_state && read_started_ms - _last_change >= _held_threshold && _pressedForCallback) {
+	else if (_current_state && read_started_ms - _last_change >= _held_threshold && _pressed_for_callback) {
 		// button has been pressed for at least the given time 
 		_was_btn_held = true;
 		// reset short presses counters.
 		_short_press_count = 0;
 		_first_press_time = 0;
 		// call the callback function for a long press event if it exist and if it has not been called yet.
-		if (_pressedForCallback && !_held_callback_called) {
+		if (_pressed_for_callback && !_held_callback_called) {
 			_held_callback_called = true; // set as called.
-			_pressedForCallback();
+			_pressed_for_callback();
 		}
 	}
 

--- a/src/EasyButton.cpp
+++ b/src/EasyButton.cpp
@@ -7,7 +7,8 @@
 
 #include "EasyButton.h"
 
-void EasyButton::begin() {
+void EasyButton::begin()
+{
 	pinMode(_pin, _pu_enabled ? INPUT_PULLUP : INPUT);
 	_current_state = digitalRead(_pin);
 	if (_invert) _current_state = !_current_state;
@@ -17,20 +18,22 @@ void EasyButton::begin() {
 	_last_change = _time;
 }
 
-void EasyButton::onPressed(EasyButton::callback_t callback) {
-	mPressedCallback = callback;
+void EasyButton::onPressed(EasyButton::callback_t callback)
+{
+	_pressedCallback = callback;
 }
 
-void EasyButton::onPressedFor(uint32_t duration, EasyButton::callback_t callback) {
+void EasyButton::onPressedFor(uint32_t duration, EasyButton::callback_t callback)
+{
 	_held_threshold = duration;
-	mPressedForCallback = callback;
+	_pressedForCallback = callback;
 }
 
 void EasyButton::onSequence(uint8_t sequences, uint32_t duration, EasyButton::callback_t callback)
 {
 	_press_sequences = sequences;
 	_press_sequence_duration = duration;
-	mPressedSequenceCallback = callback;
+	_pressedSequenceCallback = callback;
 }
 
 bool EasyButton::isPressed()
@@ -63,7 +66,8 @@ bool EasyButton::releasedFor(uint32_t duration)
 	return !_current_state && _time - _last_change >= duration;
 }
 
-bool EasyButton::read() {
+bool EasyButton::read()
+{
 
 	// get current millis.
 	uint32_t read_started_ms = millis();
@@ -74,16 +78,14 @@ bool EasyButton::read() {
 	// if invert = true, invert Button's pin value. 
 	if (_invert) {
 		pinVal = !pinVal;
-	};
+	}
 
 	// detect change on button's state.
-	if (read_started_ms - _last_change < _db_time)
-	{
+	if (read_started_ms - _last_change < _db_time) {
 		// button's state has not changed.
 		_changed = false;
 	}
-	else
-	{
+	else {
 		// button's state has changed.
 		_last_state = _current_state;				// save last state.
 		_current_state = pinVal;					// assign new state as current state from pin's value.
@@ -106,18 +108,18 @@ bool EasyButton::read() {
 			_short_press_count++;
 			// button is not being held.
 			// call the callback function for a short press event if it exist.
-			if (mPressedCallback) {
-				mPressedCallback();
+			if (_pressedCallback) {
+				_pressedCallback();
 			}
 
 			if (_short_press_count == _press_sequences && _press_sequence_duration >= (read_started_ms - _first_press_time)) {
-				if (mPressedSequenceCallback) {
-					mPressedSequenceCallback();
+				if (_pressedSequenceCallback) {
+					_pressedSequenceCallback();
 				}
 				_short_press_count = 0;
 				_first_press_time = 0;
 			}
-			// if secuence timeout, reset short presses counters.
+			// if sequence timeout, reset short presses counters.
 			else if (_press_sequence_duration <= (read_started_ms - _first_press_time)) {
 				_short_press_count = 0;
 				_first_press_time = 0;
@@ -127,20 +129,20 @@ bool EasyButton::read() {
 		else {
 			_was_btn_held = false;
 		}
-		// since button released, reset mPressedForCallbackCalled value.
+		// since button released, reset _pressedForCallbackCalled value.
 		_held_callback_called = false;
 	}
 	// button is not released.
-	else if (_current_state && read_started_ms - _last_change >= _held_threshold && mPressedForCallback) {
+	else if (_current_state && read_started_ms - _last_change >= _held_threshold && _pressedForCallback) {
 		// button has been pressed for at least the given time 
 		_was_btn_held = true;
 		// reset short presses counters.
 		_short_press_count = 0;
 		_first_press_time = 0;
 		// call the callback function for a long press event if it exist and if it has not been called yet.
-		if (mPressedForCallback && !_held_callback_called) {
+		if (_pressedForCallback && !_held_callback_called) {
 			_held_callback_called = true; // set as called.
-			mPressedForCallback();
+			_pressedForCallback();
 		}
 	}
 

--- a/src/EasyButton.h
+++ b/src/EasyButton.h
@@ -26,7 +26,7 @@ public:
 #else
 	typedef void(*callback_t)();
 #endif
-	EasyButton(uint8_t pin, uint32_t dbTime = 35, bool puEnable = true, bool invert = true) : _pin(pin), _db_time(dbTime), _invert(invert), _pu_enabled(puEnable) {}
+	EasyButton(uint8_t pin, uint32_t debounce_time = 35, bool pullup_enable = true, bool invert = true) : _pin(pin), _db_time(debounce_time), _invert(invert), _pu_enabled(pullup_enable) {}
 	~EasyButton() {}
 	// PUBLIC FUNCTIONS
 	void begin();																// Initialize a button object and the pin it's connected to.	
@@ -59,9 +59,9 @@ private:
 	uint32_t _time;						// Time of current state.
 	uint32_t _last_change;				// Time of last state change.
 	// CALLBACKS
-	callback_t _pressedCallback;			// Callback function for pressed events.
-	callback_t _pressedForCallback;			// Callback function for pressedFor events.
-	callback_t _pressedSequenceCallback;	// Callback function for pressedSequence events.
+	callback_t _pressed_callback;			// Callback function for pressed events.
+	callback_t _pressed_for_callback;			// Callback function for pressedFor events.
+	callback_t _pressed_sequence_callback;	// Callback function for pressedSequence events.
 };
 
 #endif

--- a/src/EasyButton.h
+++ b/src/EasyButton.h
@@ -27,7 +27,7 @@ public:
 	typedef void(*callback_t)();
 #endif
 	EasyButton(uint8_t pin, uint32_t dbTime = 35, bool puEnable = true, bool invert = true) : _pin(pin), _db_time(dbTime), _invert(invert), _pu_enabled(puEnable) {}
-	~EasyButton() {};
+	~EasyButton() {}
 	// PUBLIC FUNCTIONS
 	void begin();																// Initialize a button object and the pin it's connected to.	
 	bool read();																// Returns the current debounced button state, true for pressed, false for released.
@@ -59,9 +59,9 @@ private:
 	uint32_t _time;						// Time of current state.
 	uint32_t _last_change;				// Time of last state change.
 	// CALLBACKS
-	callback_t mPressedCallback;			// Callback function for pressed events.
-	callback_t mPressedForCallback;			// Callback function for pressedFor events.
-	callback_t mPressedSequenceCallback;	// Callback function for pressedSequence events.
+	callback_t _pressedCallback;			// Callback function for pressed events.
+	callback_t _pressedForCallback;			// Callback function for pressedFor events.
+	callback_t _pressedSequenceCallback;	// Callback function for pressedSequence events.
 };
 
 #endif


### PR DESCRIPTION
I have seen some coding style inconsistencies on the source files, and I have suggested some fixes to them:

* **Member variables naming**: the callback members were prefixed with an `m` (`mPressedCallback`), while other members were prefixed `_` (`_time`), so I renamed the callbacks.
* **Examples indentation**: `MultipleButtons.ino` was indented with 2 spaces, while the other examples were using tabs, so I changed all examples to 2 spaces since it's the Arduino default.
* **Opening braces positioning**: braces for some methods were on the same line as the method name, and some if/else braces were on the following line. I adopted what was most used (method braces on the following line, and if/else braces on the same line).
* **Camel case**: there were also some variables that used the camel case scheme (`dbTime`, `_pressedCallback`), while the majority use underscores.
* **Constructor parameter abbreviations**: I think the constructor parameters should not be abbreviated because it gets a little bit harder to understand their meaning, so I expanded `dbTime` and `puEnable` to `debounce_time` and `pullup_enable`.

Please feel free to give me feedback, or to ask me to roll back some changes.