### PR TITLE
Add ESP32 touch support

### DIFF
--- a/src/EasyButton.cpp
+++ b/src/EasyButton.cpp
@@ -10,7 +10,7 @@
 void EasyButton::begin()
 {
 	pinMode(_pin, _pu_enabled ? INPUT_PULLUP : INPUT);
-	_current_state = digitalRead(_pin);
+	_current_state = _readPin();
 	if (_invert) _current_state = !_current_state;
 	_time = millis();
 	_last_state = _current_state;
@@ -73,7 +73,7 @@ bool EasyButton::read()
 	uint32_t read_started_ms = millis();
 
 	// read pin value.
-	bool pinVal = digitalRead(_pin);
+	bool pinVal = _readPin();
 
 	// if invert = true, invert Button's pin value. 
 	if (_invert) {
@@ -149,4 +149,9 @@ bool EasyButton::read()
 	_time = read_started_ms;
 
 	return _current_state;
+}
+
+bool EasyButton::_readPin()
+{
+	return digitalRead(_pin);
 }

--- a/src/EasyButton.h
+++ b/src/EasyButton.h
@@ -29,7 +29,7 @@ public:
 	EasyButton(uint8_t pin, uint32_t debounce_time = 35, bool pullup_enable = true, bool invert = true) : _pin(pin), _db_time(debounce_time), _invert(invert), _pu_enabled(pullup_enable) {}
 	~EasyButton() {}
 	// PUBLIC FUNCTIONS
-	void begin();																// Initialize a button object and the pin it's connected to.	
+	virtual void begin();														// Initialize a button object and the pin it's connected to.
 	bool read();																// Returns the current debounced button state, true for pressed, false for released.
 	void onPressed(callback_t callback);										// Call a callback function when the button has been pressed and released.
 	void onPressedFor(uint32_t duration, callback_t callback);					// Call a callback function when the button has been held for at least the given number of milliseconds.
@@ -62,6 +62,8 @@ private:
 	callback_t _pressed_callback;			// Callback function for pressed events.
 	callback_t _pressed_for_callback;			// Callback function for pressedFor events.
 	callback_t _pressed_sequence_callback;	// Callback function for pressedSequence events.
+
+	virtual bool _readPin();			// Abstracts the pin value reading.
 };
 
 #endif

--- a/src/EasyButton.h
+++ b/src/EasyButton.h
@@ -20,6 +20,7 @@
 
 class EasyButton
 {
+	friend class EasyButtonTouch;
 public:
 #ifdef EASYBUTTON_FUNCTIONAL_SUPPORT
 	typedef std::function<void()> callback_t;

--- a/src/EasyButtonTouch.cpp
+++ b/src/EasyButtonTouch.cpp
@@ -1,0 +1,22 @@
+/**
+ * EasyButtonTouch.cpp
+ * @author Evert Arias, Gutierrez PS
+ * @version 1.0.0
+ * @license MIT
+ */
+
+#include "EasyButtonTouch.h"
+
+void EasyButtonTouch::begin()
+{
+	_current_state = _readPin();
+	_time = millis();
+	_last_state = _current_state;
+	_changed = false;
+	_last_change = _time;
+}
+
+bool EasyButtonTouch::_readPin()
+{
+	return touchRead(_pin) < _touch_threshold;
+}

--- a/src/EasyButtonTouch.h
+++ b/src/EasyButtonTouch.h
@@ -1,0 +1,25 @@
+/**
+ * EasyButtonTouch.h
+ * @author Evert Arias, Gutierrez PS
+ * @version 1.0.0
+ * @license MIT
+ */
+
+#ifndef _EasyButtonTouch_h
+#define _EasyButtonTouch_h
+
+#include <Arduino.h>
+#include "EasyButton.h"
+
+class EasyButtonTouch : public EasyButton
+{
+public:
+	EasyButtonTouch(uint8_t pin, uint32_t debounce_time = 35, uint16_t threshold = 50) : EasyButton(pin, debounce_time, false, false), _touch_threshold(threshold) {}
+	void begin();
+private:
+	uint16_t _touch_threshold;		// If touchRead() is below the threshold, the button is considered pressed
+	
+	bool _readPin();
+};
+
+#endif


### PR DESCRIPTION
Hi again. I was able to add support to ESP32 capacitive touch inputs, reading their state with `touchRead()` function from the Arduino core. [Here is a tutorial about this feature](https://randomnerdtutorials.com/esp32-touch-pins-arduino-ide/).

First I made some modifications to `EasyButton` class: I added a private virtual method called `_readPin()` that abstracts the pin reading, and also made `begin()` virtual in order to allow overrides.

After that I created the friend class `EasyButtonTouch` that is constructed with different parameters, and overrides `_readPin()` and `begin()` from `EasyButton`.

As in the last time, please feel free to give me feedback and request changes. If you wish to merge this feature, I can write examples and document it better.