### PR TITLE
Sequence fixes

### DIFF
--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -1,12 +1,13 @@
 #include "Sequence.h"
 
-Sequence Sequence::operator=(const Sequence& sequence)
+Sequence& Sequence::operator=(const Sequence& sequence)
 {
     _press_sequence_duration = sequence._press_sequence_duration;
     _first_press_time = sequence._first_press_time;
     _press_sequences = sequence._press_sequences;
     _short_press_count = sequence._short_press_count;
-	_is_enabled = sequence._is_enabled;
+    _is_enabled = sequence._is_enabled;
+    return *this;
 }
 
 bool Sequence::newPress(uint32_t read_started_ms)
@@ -20,7 +21,7 @@ bool Sequence::newPress(uint32_t read_started_ms)
 
 		if (_short_press_count == _press_sequences && _press_sequence_duration >= (read_started_ms - _first_press_time))
 		{ //true-> pressed_sequence
-			reset();			
+			reset();
 			return true;
 		}
 

--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -1,15 +1,5 @@
 #include "Sequence.h"
 
-Sequence& Sequence::operator=(const Sequence& sequence)
-{
-    _press_sequence_duration = sequence._press_sequence_duration;
-    _first_press_time = sequence._first_press_time;
-    _press_sequences = sequence._press_sequences;
-    _short_press_count = sequence._short_press_count;
-    _is_enabled = sequence._is_enabled;
-    return *this;
-}
-
 bool Sequence::newPress(uint32_t read_started_ms)
 {
 	if(_is_enabled)

--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -22,8 +22,6 @@ public:
 
     Sequence(){}
 
-    Sequence& operator=(const Sequence& sequence);
-
     bool newPress(uint32_t read_started_ms);
 
     void reset();

--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -20,7 +20,7 @@ public:
     {
     }
 
-    Sequence(){}
+    Sequence() : Sequence(0, 0){}
 
     bool newPress(uint32_t read_started_ms);
 

--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -12,7 +12,7 @@ private:
     uint32_t _short_press_count;		// Short press counter.
 
 public:
-    Sequence(uint8_t sequences, uint32_t duration):_press_sequences(sequences), 
+    Sequence(uint8_t sequences, uint32_t duration):_press_sequences(sequences),
     _press_sequence_duration(duration)
     {
         _short_press_count = 0;
@@ -21,7 +21,7 @@ public:
 
     Sequence(){}
 
-    Sequence operator=(const Sequence& sequence);
+    Sequence& operator=(const Sequence& sequence);
 
     bool newPress(uint32_t read_started_ms);
 

--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -12,11 +12,11 @@ private:
     uint32_t _short_press_count;		// Short press counter.
 
 public:
-    Sequence(uint8_t sequences, uint32_t duration):_press_sequences(sequences),
-    _press_sequence_duration(duration)
+    Sequence(uint8_t sequences, uint32_t duration) : _is_enabled(false),
+    _press_sequences(sequences),
+    _press_sequence_duration(duration),
+    _short_press_count(0)
     {
-        _short_press_count = 0;
-        _is_enabled = false;
     }
 
     Sequence(){}

--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -15,6 +15,7 @@ public:
     Sequence(uint8_t sequences, uint32_t duration) : _is_enabled(false),
     _press_sequences(sequences),
     _press_sequence_duration(duration),
+    _first_press_time(0),
     _short_press_count(0)
     {
     }


### PR DESCRIPTION
Fixes for the `Sequence` class:

- missing `operator=` return value added and type corrected to `T&` (causes build errors on compilations with warnings enabled)
- remaining member initializations moved to ctor initializer list