### PR TITLE
Allow MAX_SEQUENCES to be overriden on build

### DIFF
--- a/src/EasyButtonBase.h
+++ b/src/EasyButtonBase.h
@@ -21,7 +21,11 @@
 #endif
 
 #ifndef EASYBUTTON_DO_NOT_USE_SEQUENCES
+#ifndef EASYBUTTON_MAX_SEQUENCES
 #define MAX_SEQUENCES 5
+#else
+#define MAX_SEQUENCES EASYBUTTON_MAX_SEQUENCES
+#endif
 #endif
 
 class EasyButtonBase


### PR DESCRIPTION
Love the lib :)

This is useful to not consume unnecessary SRAM when only requiring, e.g. a single sequence, giving the possibility of saving a fair amount of resources in such cases.

In my testing, on Arduino UNO, setting EASYBUTTON_MAX_SEQUENCES to 1 saves 64 bytes.