### PR TITLE
Conditional touch features, fixes #74

### DIFF
--- a/src/EasyButtonTouch.cpp
+++ b/src/EasyButtonTouch.cpp
@@ -7,7 +7,7 @@
 
 #if defined(ESP32)
 #include "EasyButtonTouch.h"
-#if defined(SOC_TOUCH_SENSOR_SUPPORTED)
+#if defined(SOC_TOUCH_SENSOR_SUPPORTED) || (defined(SOC_TOUCH_SENSOR_NUM) && SOC_TOUCH_SENSOR_NUM > 1)
 
 void EasyButtonTouch::setThreshold(int threshold)
 {

--- a/src/EasyButtonTouch.cpp
+++ b/src/EasyButtonTouch.cpp
@@ -7,6 +7,7 @@
 
 #if defined(ESP32)
 #include "EasyButtonTouch.h"
+#if defined(SOC_TOUCH_SENSOR_SUPPORTED)
 
 void EasyButtonTouch::setThreshold(int threshold)
 {
@@ -33,5 +34,5 @@ bool EasyButtonTouch::_readPin()
 	ADCFilter.Filter(touchRead(_pin));
 	return ADCFilter.Current() < _touch_threshold;
 }
-
+#endif
 #endif

--- a/src/EasyButtonTouch.h
+++ b/src/EasyButtonTouch.h
@@ -7,6 +7,8 @@
 
 #if !defined(_EasyButtonTouch_h) and defined(ESP32)
 #define _EasyButtonTouch_h
+#include <include/soc/soc_caps.h>
+#if defined(SOC_TOUCH_SENSOR_SUPPORTED)
 
 #include <Arduino.h>
 #include <Filter.h>
@@ -26,5 +28,5 @@ private:
 
 	bool _readPin();
 };
-
+#endif
 #endif

--- a/src/EasyButtonTouch.h
+++ b/src/EasyButtonTouch.h
@@ -8,7 +8,7 @@
 #if !defined(_EasyButtonTouch_h) and defined(ESP32)
 #define _EasyButtonTouch_h
 #include <include/soc/soc_caps.h>
-#if defined(SOC_TOUCH_SENSOR_SUPPORTED)
+#if defined(SOC_TOUCH_SENSOR_SUPPORTED) || (defined(SOC_TOUCH_SENSOR_NUM) && SOC_TOUCH_SENSOR_NUM > 1)
 
 #include <Arduino.h>
 #include <Filter.h>


### PR DESCRIPTION
Some ESP32 variants (C3 speciifcally) do not support touch inputs. The changes in this PR check for this rather than assuming all ESP32s support touch, before including these features.